### PR TITLE
Application user registration service

### DIFF
--- a/dom/src/main/java/org/isisaddons/module/security/userreg/SecurityModuleAppUserRegistrationService.java
+++ b/dom/src/main/java/org/isisaddons/module/security/userreg/SecurityModuleAppUserRegistrationService.java
@@ -21,6 +21,7 @@ import javax.inject.Inject;
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.services.userreg.UserRegistrationService;
 import org.apache.isis.applib.value.Password;
+import org.isisaddons.module.security.dom.role.ApplicationRole;
 import org.isisaddons.module.security.dom.user.ApplicationUser;
 import org.isisaddons.module.security.dom.user.ApplicationUsers;
 
@@ -39,8 +40,9 @@ public class SecurityModuleAppUserRegistrationService implements UserRegistratio
         final String emailAddress) {
 
         final Password password = new Password(passwordStr);
+        ApplicationRole initialRole = getInitialRole();
         Boolean enabled = true;
-        applicationUsers.newLocalUser(username, password, password, /*initialRole*/ null, enabled, emailAddress);
+        applicationUsers.newLocalUser(username, password, password, initialRole, enabled, emailAddress);
     }
 
     @Override
@@ -57,6 +59,10 @@ public class SecurityModuleAppUserRegistrationService implements UserRegistratio
             passwordUpdated = true;
         }
         return passwordUpdated;
+    }
+
+    protected ApplicationRole getInitialRole() {
+        return null;
     }
 
     @Inject

--- a/dom/src/main/java/org/isisaddons/module/security/userreg/SecurityModuleAppUserRegistrationServiceAbstract.java
+++ b/dom/src/main/java/org/isisaddons/module/security/userreg/SecurityModuleAppUserRegistrationServiceAbstract.java
@@ -18,15 +18,17 @@ package org.isisaddons.module.security.userreg;
 
 import javax.inject.Inject;
 
-import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.services.userreg.UserRegistrationService;
 import org.apache.isis.applib.value.Password;
 import org.isisaddons.module.security.dom.role.ApplicationRole;
 import org.isisaddons.module.security.dom.user.ApplicationUser;
 import org.isisaddons.module.security.dom.user.ApplicationUsers;
 
-@DomainService
-public class SecurityModuleAppUserRegistrationService implements UserRegistrationService {
+/**
+ * An abstract implementation of {@link org.apache.isis.applib.services.userreg.UserRegistrationService}
+ * with a single abstract method for the initial role of newly created local users
+ */
+public abstract class SecurityModuleAppUserRegistrationServiceAbstract implements UserRegistrationService {
 
     @Override
     public boolean usernameExists(String username) {
@@ -61,9 +63,10 @@ public class SecurityModuleAppUserRegistrationService implements UserRegistratio
         return passwordUpdated;
     }
 
-    protected ApplicationRole getInitialRole() {
-        return null;
-    }
+    /**
+     * @return The role to use for newly created local users
+     */
+    protected abstract ApplicationRole getInitialRole();
 
     @Inject
     private ApplicationUsers applicationUsers;

--- a/webapp/src/main/java/org/isisaddons/module/security/webapp/AppUserRegistrationService.java
+++ b/webapp/src/main/java/org/isisaddons/module/security/webapp/AppUserRegistrationService.java
@@ -1,0 +1,27 @@
+package org.isisaddons.module.security.webapp;
+
+import org.apache.isis.applib.annotation.DomainService;
+import org.isisaddons.module.security.dom.role.ApplicationRole;
+import org.isisaddons.module.security.dom.role.ApplicationRoles;
+import org.isisaddons.module.security.fixture.scripts.roles.ExampleFixtureScriptsRoleAndPermissions;
+import org.isisaddons.module.security.userreg.SecurityModuleAppUserRegistrationService;
+
+import javax.inject.Inject;
+
+/**
+ * An override of the default impl of {@link org.apache.isis.applib.services.userreg.UserRegistrationService}
+ * that uses {@link org.isisaddons.module.security.fixture.scripts.roles.ExampleFixtureScriptsRoleAndPermissions#ROLE_NAME}
+ * as initial role
+ */
+@DomainService
+public class AppUserRegistrationService extends SecurityModuleAppUserRegistrationService {
+
+    @Override
+    protected ApplicationRole getInitialRole() {
+        ApplicationRole role = applicationRoles.findRoleByName(ExampleFixtureScriptsRoleAndPermissions.ROLE_NAME);
+        return role;
+    }
+
+    @Inject
+    private ApplicationRoles applicationRoles;
+}

--- a/webapp/src/main/java/org/isisaddons/module/security/webapp/AppUserRegistrationService.java
+++ b/webapp/src/main/java/org/isisaddons/module/security/webapp/AppUserRegistrationService.java
@@ -4,7 +4,7 @@ import org.apache.isis.applib.annotation.DomainService;
 import org.isisaddons.module.security.dom.role.ApplicationRole;
 import org.isisaddons.module.security.dom.role.ApplicationRoles;
 import org.isisaddons.module.security.fixture.scripts.roles.ExampleFixtureScriptsRoleAndPermissions;
-import org.isisaddons.module.security.userreg.SecurityModuleAppUserRegistrationService;
+import org.isisaddons.module.security.userreg.SecurityModuleAppUserRegistrationServiceAbstract;
 
 import javax.inject.Inject;
 
@@ -14,7 +14,7 @@ import javax.inject.Inject;
  * as initial role
  */
 @DomainService
-public class AppUserRegistrationService extends SecurityModuleAppUserRegistrationService {
+public class AppUserRegistrationService extends SecurityModuleAppUserRegistrationServiceAbstract {
 
     @Override
     protected ApplicationRole getInitialRole() {

--- a/webapp/src/main/webapp/WEB-INF/isis.properties
+++ b/webapp/src/main/webapp/WEB-INF/isis.properties
@@ -32,6 +32,7 @@ isis.services-installer=configuration-and-annotation
 isis.services.ServicesInstallerFromAnnotation.packagePrefix=org.isisaddons.module.security
 
 isis.services = \
+                org.isisaddons.module.security.webapp.AppUserRegistrationService,\
                 org.apache.isis.objectstore.jdo.applib.service.exceprecog.ExceptionRecognizerCompositeForJdoObjectStore,\
                 \
                 org.isisaddons.module.security.dom.password.PasswordEncryptionServiceUsingJBcrypt,\

--- a/webapp/src/main/webapp/WEB-INF/isis.properties
+++ b/webapp/src/main/webapp/WEB-INF/isis.properties
@@ -41,6 +41,9 @@ isis.services = \
                 \
                 #
 
+isis.fixtures= \
+                org.isisaddons.module.security.fixture.scripts.SecurityModuleAppSetUp
+
 isis.reflector.facet.cssClassFa.patterns=\
                         new.*:fa-plus,\
                         add.*:fa-plus-square,\


### PR DESCRIPTION
Made `SecurityModuleAppUserRegistrationService` an abstract class.
All specializations should implement `getInitialRole()` - returning a role to be used for newly created users.