### PR TITLE
Allow ApplicationTenancy paths length <= 255

### DIFF
--- a/dom/src/main/java/org/isisaddons/module/security/dom/tenancy/ApplicationTenancy.java
+++ b/dom/src/main/java/org/isisaddons/module/security/dom/tenancy/ApplicationTenancy.java
@@ -128,7 +128,7 @@ public class ApplicationTenancy implements Comparable<ApplicationTenancy> {
 
     // //////////////////////////////////////
 
-    public static final int MAX_LENGTH_PATH = 30;
+    public static final int MAX_LENGTH_PATH = 255;
     public static final int MAX_LENGTH_NAME = 40;
     public static final int TYPICAL_LENGTH_NAME = 20;
 


### PR DESCRIPTION
On a currently developed project different tenancies are defined for each account, who has an ApplicationUser associated.

As the ApplicationUser name must be unique among all users, the most natural way to represent its path is to use it as the path specification (alone or appended to something like "accounts/[applicationUserName]".