### PR TITLE
Multiple code improvements - squid:S1186, squid:MethodCyclomaticComplexity, squid:S1151

### DIFF
--- a/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClass.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClass.java
@@ -45,6 +45,7 @@ public class ApplicationClass extends ApplicationFeatureViewModel {
     //region > constructors
 
     public ApplicationClass() {
+        // Default constructor
     }
 
     public ApplicationClass(final ApplicationFeatureId featureId) {

--- a/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClassAction.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClassAction.java
@@ -38,6 +38,7 @@ public class ApplicationClassAction extends ApplicationClassMember {
     //region > constructors
 
     public ApplicationClassAction() {
+        // Default constructor
     }
 
     public ApplicationClassAction(final ApplicationFeatureId featureId) {

--- a/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClassCollection.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClassCollection.java
@@ -35,7 +35,9 @@ public class ApplicationClassCollection extends ApplicationClassMember {
 
     //region > constructors
 
-    public ApplicationClassCollection() {}
+    public ApplicationClassCollection() {
+        // Default constructor
+    }
 
     public ApplicationClassCollection(final ApplicationFeatureId featureId) {
         super(featureId);

--- a/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClassProperty.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationClassProperty.java
@@ -36,6 +36,7 @@ public class ApplicationClassProperty extends ApplicationClassMember {
 
     //region > constructors
     public ApplicationClassProperty() {
+        // Default constructor
     }
 
     public ApplicationClassProperty(final ApplicationFeatureId featureId) {

--- a/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationFeatureViewModel.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationFeatureViewModel.java
@@ -84,19 +84,24 @@ public abstract class ApplicationFeatureViewModel implements ViewModel {
             case CLASS:
                 return ApplicationClass.class;
             case MEMBER:
-            final ApplicationFeature feature = applicationFeatureRepository.findFeature(featureId);
-                if(feature == null) {
-                    // TODO: not sure why, yet...
-                    return null;
-                }
-                switch(feature.getMemberType()) {
-                    case PROPERTY:
-                        return ApplicationClassProperty.class;
-                    case COLLECTION:
-                        return ApplicationClassCollection.class;
-                    case ACTION:
-                        return ApplicationClassAction.class;
-                }
+                return getFeatureMemberClassType(featureId, applicationFeatureRepository.findFeature(featureId));
+        }
+        throw new IllegalArgumentException("could not determine feature type; featureId = " + featureId);
+    }
+
+    private static Class<? extends ApplicationFeatureViewModel> getFeatureMemberClassType(
+            final ApplicationFeatureId featureId, ApplicationFeature feature) {
+        if(feature == null) {
+            // TODO: not sure why, yet...
+            return null;
+        }
+        switch(feature.getMemberType()) {
+            case PROPERTY:
+                return ApplicationClassProperty.class;
+            case COLLECTION:
+                return ApplicationClassCollection.class;
+            case ACTION:
+                return ApplicationClassAction.class;
         }
         throw new IllegalArgumentException("could not determine feature type; featureId = " + featureId);
     }

--- a/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationPackage.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/feature/ApplicationPackage.java
@@ -42,6 +42,7 @@ public class ApplicationPackage extends ApplicationFeatureViewModel {
     //region > constructors
 
     public ApplicationPackage() {
+        // Default constructor
     }
 
     public ApplicationPackage(final ApplicationFeatureId featureId) {

--- a/dom/src/main/java/org/isisaddons/module/security/app/user/UserPermissionViewModel.java
+++ b/dom/src/main/java/org/isisaddons/module/security/app/user/UserPermissionViewModel.java
@@ -84,6 +84,7 @@ public class UserPermissionViewModel implements ViewModel {
     }
 
     public UserPermissionViewModel() {
+        // Default constructor
     }
     //endregion
 

--- a/dom/src/main/java/org/isisaddons/module/security/shiro/PrincipalCollectionWithSinglePrincipalForApplicationUserInAnyRealm.java
+++ b/dom/src/main/java/org/isisaddons/module/security/shiro/PrincipalCollectionWithSinglePrincipalForApplicationUserInAnyRealm.java
@@ -6,6 +6,7 @@ import org.apache.shiro.subject.SimplePrincipalCollection;
 public class PrincipalCollectionWithSinglePrincipalForApplicationUserInAnyRealm extends SimplePrincipalCollection {
 
     public PrincipalCollectionWithSinglePrincipalForApplicationUserInAnyRealm() {
+        // Default constructor
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1186 - Methods should not be empty.
squid:MethodCyclomaticComplexity - Methods should not be too complex.
squid:S1151 - "switch case" clauses should not have too many lines.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1186
https://dev.eclipse.org/sonar/rules/show/squid:MethodCyclomaticComplexity
https://dev.eclipse.org/sonar/rules/show/squid:S1151
Please let me know if you have any questions.
George Kankava