### PR TITLE
adds autoActivateUser to IsisModuleSecurityRealm

### DIFF
--- a/dom/src/main/java/org/isisaddons/module/security/shiro/IsisModuleSecurityRealm.java
+++ b/dom/src/main/java/org/isisaddons/module/security/shiro/IsisModuleSecurityRealm.java
@@ -144,7 +144,11 @@ public class IsisModuleSecurityRealm extends AuthorizingRealm {
 
             private ApplicationUser lookupUser() {
                 if (autoCreateUser) {
-                    return applicationUserRepository.findOrCreateUserByUsername(username);
+                    ApplicationUser applicationUser = applicationUserRepository.findOrCreateUserByUsername(username);
+                    if (autoActivateUser) {
+                        applicationUser.unlock();
+                    }
+                    return applicationUser;
                 } else {
                     return applicationUserRepository.findByUsername(username);
                 }
@@ -212,6 +216,16 @@ public class IsisModuleSecurityRealm extends AuthorizingRealm {
     public void setAutoCreateUser(boolean autoCreateUser) {
         this.autoCreateUser = autoCreateUser;
     }
+
+    //endregion
+
+    //region > autoActivateUser
+
+    private boolean autoActivateUser = false;
+
+    public boolean getAutoActivateUser() { return autoActivateUser; }
+
+    public void setAutoActivateUser(boolean autoActivateUser) { this.autoActivateUser = autoActivateUser; }
 
     //endregion
 


### PR DESCRIPTION
This commits adds a boolean flag to the IsisModuleSecurityRealm class
and enables the automatic activation of delegated user accounts.
This makes it easier for us, to include customer LDAP's and takes away
the needed maintainence of user accounts for all our services.